### PR TITLE
Fix MSan false positive: enlarge dummy buffer for SVE predicated loads

### DIFF
--- a/c/lib.c
+++ b/c/lib.c
@@ -291,8 +291,11 @@ SIMSIMD_DYNAMIC simsimd_capability_t simsimd_capabilities(void) {
     simsimd_distance_t *dummy_results = &dummy_results_buffer[0];
 
     // Passing `NULL` as `x` will trigger all kinds of `nonull` warnings on GCC.
+    // The buffer must be large enough to cover the widest SIMD register (SVE: up to 2048 bits = 256 bytes).
+    // SVE functions use `do { } while (i < n)` loops that execute once even with n=0, and MemorySanitizer
+    // instruments predicated loads as full-width reads, so all bytes must be initialized.
     typedef double largest_scalar_t;
-    largest_scalar_t dummy_input[1] = {0};
+    largest_scalar_t dummy_input[32] = {0};
     void *x = &dummy_input[0];
 
     // Dense:

--- a/include/simsimd/types.h
+++ b/include/simsimd/types.h
@@ -29,13 +29,22 @@
 //
 // On GCC we mark the functions as `nonnull` informing that none of the arguments can be `NULL`.
 // Marking with `pure` and `const` isn't possible as outputting to a pointer is a "side effect".
+//
+// MemorySanitizer cannot track data flow through SIMD intrinsics (SVE, NEON, SSE, AVX),
+// causing false-positive "use-of-uninitialized-value" reports. Disable MSan instrumentation
+// for all SimSIMD functions since they are entirely SIMD code.
+#if defined(__has_feature) && __has_feature(memory_sanitizer)
+#define _SIMSIMD_NO_SANITIZE_MEMORY __attribute__((no_sanitize("memory")))
+#else
+#define _SIMSIMD_NO_SANITIZE_MEMORY
+#endif
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define SIMSIMD_DYNAMIC __declspec(dllexport)
 #define SIMSIMD_PUBLIC inline static
 #define SIMSIMD_INTERNAL inline static
 #elif defined(__GNUC__) || defined(__clang__)
-#define SIMSIMD_DYNAMIC __attribute__((visibility("default"))) __attribute__((nonnull))
-#define SIMSIMD_PUBLIC __attribute__((unused, nonnull)) inline static
+#define SIMSIMD_DYNAMIC __attribute__((visibility("default"))) __attribute__((nonnull)) _SIMSIMD_NO_SANITIZE_MEMORY
+#define SIMSIMD_PUBLIC __attribute__((unused, nonnull)) _SIMSIMD_NO_SANITIZE_MEMORY inline static
 #define SIMSIMD_INTERNAL __attribute__((always_inline)) inline static
 #else
 #define SIMSIMD_DYNAMIC

--- a/include/simsimd/types.h
+++ b/include/simsimd/types.h
@@ -29,22 +29,13 @@
 //
 // On GCC we mark the functions as `nonnull` informing that none of the arguments can be `NULL`.
 // Marking with `pure` and `const` isn't possible as outputting to a pointer is a "side effect".
-//
-// MemorySanitizer cannot track data flow through SIMD intrinsics (SVE, NEON, SSE, AVX),
-// causing false-positive "use-of-uninitialized-value" reports. Disable MSan instrumentation
-// for all SimSIMD functions since they are entirely SIMD code.
-#if defined(__has_feature) && __has_feature(memory_sanitizer)
-#define _SIMSIMD_NO_SANITIZE_MEMORY __attribute__((no_sanitize("memory")))
-#else
-#define _SIMSIMD_NO_SANITIZE_MEMORY
-#endif
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define SIMSIMD_DYNAMIC __declspec(dllexport)
 #define SIMSIMD_PUBLIC inline static
 #define SIMSIMD_INTERNAL inline static
 #elif defined(__GNUC__) || defined(__clang__)
-#define SIMSIMD_DYNAMIC __attribute__((visibility("default"))) __attribute__((nonnull)) _SIMSIMD_NO_SANITIZE_MEMORY
-#define SIMSIMD_PUBLIC __attribute__((unused, nonnull)) _SIMSIMD_NO_SANITIZE_MEMORY inline static
+#define SIMSIMD_DYNAMIC __attribute__((visibility("default"))) __attribute__((nonnull))
+#define SIMSIMD_PUBLIC __attribute__((unused, nonnull)) inline static
 #define SIMSIMD_INTERNAL __attribute__((always_inline)) inline static
 #else
 #define SIMSIMD_DYNAMIC


### PR DESCRIPTION
## Summary

`simsimd_capabilities` probes SIMD functions with `n=0` to pre-initialize dispatch function pointers. SVE implementations use `do { } while (i < n)` loops that always execute the body once, even with `n=0`. MemorySanitizer instruments SVE predicated loads (`svld1_f32` etc.) as full-width vector reads regardless of the predicate mask, so it reports use-of-uninitialized memory when the buffer is smaller than the SIMD register width.

Increase the dummy buffer from 8 bytes (`double[1]`) to 256 bytes (`double[32]`) to cover the widest possible SVE vector (2048 bits).

Also reverts the `no_sanitize("memory")` approach from `types.h` since it would leave output memory poisoned for callers.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98677&sha=a1b9d7f6170c510431fce962a869aa617d88d888&name_0=PR&name_1=Stress%20test%20%28arm_msan%29