### PR TITLE
Include `<unistd.h>` for ARM POSIX capability detection

### DIFF
--- a/include/simsimd/simsimd.h
+++ b/include/simsimd/simsimd.h
@@ -121,6 +121,9 @@
 // Detect POSIX extensions availability for signal handling.
 // POSIX extensions provide `sigaction`, `sigjmp_buf`, and `sigsetjmp` for safe signal handling.
 // These are needed on Linux ARM for safely testing `mrs` instruction availability.
+#if defined(_SIMSIMD_DEFINED_LINUX)
+#include <unistd.h> // `_POSIX_VERSION`
+#endif
 #if defined(_SIMSIMD_DEFINED_LINUX) && defined(_POSIX_VERSION)
 #include <setjmp.h> // `sigjmp_buf`, `sigsetjmp`, `siglongjmp`
 #include <signal.h> // `sigaction`, `SIGILL`


### PR DESCRIPTION
`_POSIX_VERSION` is defined by `<unistd.h>`, which SimSIMD never included after https://github.com/ashvardanian/NumKong/commit/b139cc920df15eb6d69d61deb25e2a0cb8fc1fc2. The check `defined(_SIMSIMD_DEFINED_LINUX) && defined(_POSIX_VERSION)` always evaluated to false, so `_SIMSIMD_HAS_POSIX_EXTENSIONS` was always 0. This caused `_simsimd_capabilities_arm()` to take the fallback path, returning only `simsimd_cap_neon_k | simsimd_cap_serial_k` and skipping detection of all other ARM capabilities.

Test:
```c
#include <stdio.h>
#define SIMSIMD_DYNAMIC_DISPATCH 0
#include <simsimd/simsimd.h>

int main() {
    printf("_SIMSIMD_HAS_POSIX_EXTENSIONS = %d\n", _SIMSIMD_HAS_POSIX_EXTENSIONS);
    simsimd_capability_t caps = _simsimd_capabilities_arm();
    printf("capabilities = 0x%x\n", (unsigned)caps);
    printf("neon_bf16: %d\n", !!(caps & simsimd_cap_neon_bf16_k));
    printf("sve: %d\n", !!(caps & simsimd_cap_sve_k));
    return 0;
}
```
Before fix: `_SIMSIMD_HAS_POSIX_EXTENSIONS = 0`
After fix: `_SIMSIMD_HAS_POSIX_EXTENSIONS = 1`

Exact capabilities depend on hardware. On my machine all were 1.