### PR TITLE
Disable SVE targets under MemorySanitizer

### DIFF
--- a/c/lib.c
+++ b/c/lib.c
@@ -42,6 +42,20 @@
 #if !defined(SIMSIMD_TARGET_SVE2) && (defined(__linux__) || defined(__FreeBSD__))
 #define SIMSIMD_TARGET_SVE2 1
 #endif
+/*  Under MemorySanitizer, disable all SVE targets: MSAN cannot instrument ARM SVE
+ *  predicated loads or vector arithmetic, causing false "use-of-uninitialized-value"
+ *  reports even on properly initialized data.  NEON/scalar fallbacks are tracked correctly.  */
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#undef SIMSIMD_TARGET_SVE
+#define SIMSIMD_TARGET_SVE 0
+#undef SIMSIMD_TARGET_SVE2
+#define SIMSIMD_TARGET_SVE2 0
+#define SIMSIMD_TARGET_SVE_F16 0
+#define SIMSIMD_TARGET_SVE_BF16 0
+#define SIMSIMD_TARGET_SVE_I8 0
+#endif
+#endif
 #if !defined(SIMSIMD_TARGET_HASWELL) && (defined(_MSC_VER) || defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__))
 #define SIMSIMD_TARGET_HASWELL 1
 #endif


### PR DESCRIPTION
## Summary

MSAN cannot instrument ARM SVE intrinsics (predicated loads, vector arithmetic,
reductions). Even `svdupq_n_f32(0.f, ...)` — a literal constant — is flagged as
uninitialized because MSAN has no SVE-specific shadow propagation.

The existing mitigations from PRs #14 (zero-initialized probe buffer +
`SIMSIMD_UNPOISON` on results) are insufficient: MSAN reports the error **inside**
the SVE kernel during `svld1_f32`, `svmla_f32_x`, `svaddv_f32`, before control
returns to the dispatch wrapper where unpoisoning happens.

## Fix

Disable all SVE compilation targets (`SIMSIMD_TARGET_SVE`, `SVE2`, `SVE_F16`,
`SVE_BF16`, `SVE_I8`) when building with MSAN. SimSIMD automatically falls back
to NEON/scalar implementations that MSAN can track correctly.

Placed immediately after the SVE/SVE2 default definitions (line 43) so the
`#undef` + `#define 0` overrides take effect before any downstream `#if`.

## Evidence

- 4 `arm_msan` failures on ClickHouse PR #98677, all with identical
  `simsimd_cos_f32_sve` stack trace at `spatial.h:818`
- All 4 failures occurred **after** PRs #98699/#98966 (buffer init + submodule
  update) were merged, confirming the previous fixes are insufficient for SVE
- Zero NEON-related MSAN false positives in 90 days of ClickHouse CI data (CIDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)