### PR TITLE
Unpoison SVE scalar reductions for MemorySanitizer

### DIFF
--- a/include/simsimd/binary.h
+++ b/include/simsimd/binary.h
@@ -213,6 +213,7 @@ SIMSIMD_PUBLIC void simsimd_hamming_b8_sve(simsimd_b8_t const *a, simsimd_b8_t c
             ++cycle;
         } while (i < n_words && cycle < 31);
         differences += svaddv_u8(all_vec, differences_cycle_vec);
+        SIMSIMD_UNPOISON(&differences, sizeof(differences));
         differences_cycle_vec = svdup_n_u8(0);
         cycle = 0; // Reset the cycle counter.
     }
@@ -249,8 +250,10 @@ SIMSIMD_PUBLIC void simsimd_jaccard_b8_sve(simsimd_b8_t const *a, simsimd_b8_t c
             ++cycle;
         } while (i < n_words && cycle < 31);
         intersection += svaddv_u8(all_vec, intersection_cycle_vec);
+        SIMSIMD_UNPOISON(&intersection, sizeof(intersection));
         intersection_cycle_vec = svdup_n_u8(0);
         union_ += svaddv_u8(all_vec, union_cycle_vec);
+        SIMSIMD_UNPOISON(&union_, sizeof(union_));
         union_cycle_vec = svdup_n_u8(0);
         cycle = 0; // Reset the cycle counter.
     }

--- a/include/simsimd/dot.h
+++ b/include/simsimd/dot.h
@@ -652,7 +652,9 @@ SIMSIMD_PUBLIC void simsimd_dot_f32_sve(simsimd_f32_t const *a_scalars, simsimd_
         ab_vec = svmla_f32_x(pg_vec, ab_vec, a_vec, b_vec);
         idx_scalars += svcntw();
     } while (idx_scalars < count_scalars);
-    *result = svaddv_f32(svptrue_b32(), ab_vec);
+    simsimd_distance_t reduced = svaddv_f32(svptrue_b32(), ab_vec);
+    SIMSIMD_UNPOISON(&reduced, sizeof(reduced));
+    *result = reduced;
 }
 
 SIMSIMD_PUBLIC void simsimd_dot_f32c_sve(simsimd_f32c_t const *a_pairs, simsimd_f32c_t const *b_pairs,
@@ -676,6 +678,7 @@ SIMSIMD_PUBLIC void simsimd_dot_f32c_sve(simsimd_f32c_t const *a_pairs, simsimd_
     } while (idx_pairs < count_pairs);
     results[0] = svaddv_f32(svptrue_b32(), ab_real_vec);
     results[1] = svaddv_f32(svptrue_b32(), ab_imag_vec);
+    SIMSIMD_UNPOISON(results, 2 * sizeof(simsimd_distance_t));
 }
 
 SIMSIMD_PUBLIC void simsimd_vdot_f32c_sve(simsimd_f32c_t const *a_pairs, simsimd_f32c_t const *b_pairs,
@@ -699,6 +702,7 @@ SIMSIMD_PUBLIC void simsimd_vdot_f32c_sve(simsimd_f32c_t const *a_pairs, simsimd
     } while (idx_pairs < count_pairs);
     results[0] = svaddv_f32(svptrue_b32(), ab_real_vec);
     results[1] = svaddv_f32(svptrue_b32(), ab_imag_vec);
+    SIMSIMD_UNPOISON(results, 2 * sizeof(simsimd_distance_t));
 }
 
 SIMSIMD_PUBLIC void simsimd_dot_f64_sve(simsimd_f64_t const *a_scalars, simsimd_f64_t const *b_scalars,
@@ -712,7 +716,9 @@ SIMSIMD_PUBLIC void simsimd_dot_f64_sve(simsimd_f64_t const *a_scalars, simsimd_
         ab_vec = svmla_f64_x(pg_vec, ab_vec, a_vec, b_vec);
         idx_scalars += svcntd();
     } while (idx_scalars < count_scalars);
-    *result = svaddv_f64(svptrue_b32(), ab_vec);
+    simsimd_distance_t reduced = svaddv_f64(svptrue_b32(), ab_vec);
+    SIMSIMD_UNPOISON(&reduced, sizeof(reduced));
+    *result = reduced;
 }
 
 SIMSIMD_PUBLIC void simsimd_dot_f64c_sve(simsimd_f64c_t const *a_pairs, simsimd_f64c_t const *b_pairs,
@@ -736,6 +742,7 @@ SIMSIMD_PUBLIC void simsimd_dot_f64c_sve(simsimd_f64c_t const *a_pairs, simsimd_
     } while (idx_pairs < count_pairs);
     results[0] = svaddv_f64(svptrue_b64(), ab_real_vec);
     results[1] = svaddv_f64(svptrue_b64(), ab_imag_vec);
+    SIMSIMD_UNPOISON(results, 2 * sizeof(simsimd_distance_t));
 }
 
 SIMSIMD_PUBLIC void simsimd_vdot_f64c_sve(simsimd_f64c_t const *a_pairs, simsimd_f64c_t const *b_pairs,
@@ -759,6 +766,7 @@ SIMSIMD_PUBLIC void simsimd_vdot_f64c_sve(simsimd_f64c_t const *a_pairs, simsimd
     } while (idx_pairs < count_pairs);
     results[0] = svaddv_f64(svptrue_b64(), ab_real_vec);
     results[1] = svaddv_f64(svptrue_b64(), ab_imag_vec);
+    SIMSIMD_UNPOISON(results, 2 * sizeof(simsimd_distance_t));
 }
 
 #pragma clang attribute pop
@@ -780,6 +788,7 @@ SIMSIMD_PUBLIC void simsimd_dot_f16_sve(simsimd_f16_t const *a_scalars, simsimd_
         idx_scalars += svcnth();
     } while (idx_scalars < count_scalars);
     simsimd_f16_for_arm_simd_t ab = svaddv_f16(svptrue_b16(), ab_vec);
+    SIMSIMD_UNPOISON(&ab, sizeof(ab));
     *result = ab;
 }
 
@@ -804,6 +813,7 @@ SIMSIMD_PUBLIC void simsimd_dot_f16c_sve(simsimd_f16c_t const *a_pairs, simsimd_
     } while (idx_pairs < count_pairs);
     results[0] = svaddv_f16(svptrue_b16(), ab_real_vec);
     results[1] = svaddv_f16(svptrue_b16(), ab_imag_vec);
+    SIMSIMD_UNPOISON(results, 2 * sizeof(simsimd_distance_t));
 }
 
 SIMSIMD_PUBLIC void simsimd_vdot_f16c_sve(simsimd_f16c_t const *a_pairs, simsimd_f16c_t const *b_pairs,
@@ -827,6 +837,7 @@ SIMSIMD_PUBLIC void simsimd_vdot_f16c_sve(simsimd_f16c_t const *a_pairs, simsimd
     } while (idx_pairs < count_pairs);
     results[0] = svaddv_f16(svptrue_b16(), ab_real_vec);
     results[1] = svaddv_f16(svptrue_b16(), ab_imag_vec);
+    SIMSIMD_UNPOISON(results, 2 * sizeof(simsimd_distance_t));
 }
 
 #pragma clang attribute pop

--- a/include/simsimd/sparse.h
+++ b/include/simsimd/sparse.h
@@ -1283,6 +1283,7 @@ SIMSIMD_PUBLIC void simsimd_spdot_counts_u16_sve2(                  //
     }
     results[0] = (simsimd_distance_t)intersection_size;
     results[1] = svaddv_s64(svptrue_b64(), product_vec);
+    SIMSIMD_UNPOISON(results, 2 * sizeof(simsimd_distance_t));
 }
 
 #pragma clang attribute pop
@@ -1370,6 +1371,7 @@ SIMSIMD_PUBLIC void simsimd_spdot_weights_u16_sve2(                   //
     }
     results[0] = (simsimd_distance_t)intersection_size;
     results[1] = svaddv_f32(svptrue_b32(), product_vec);
+    SIMSIMD_UNPOISON(results, 2 * sizeof(simsimd_distance_t));
 }
 
 #pragma clang attribute pop

--- a/include/simsimd/spatial.h
+++ b/include/simsimd/spatial.h
@@ -809,6 +809,7 @@ SIMSIMD_PUBLIC void simsimd_l2sq_f32_sve(simsimd_f32_t const *a, simsimd_f32_t c
         i += svcntw();
     } while (i < n);
     simsimd_f32_t d2 = svaddv_f32(svptrue_b32(), d2_vec);
+    SIMSIMD_UNPOISON(&d2, sizeof(d2));
     *result = d2;
 }
 
@@ -831,6 +832,9 @@ SIMSIMD_PUBLIC void simsimd_cos_f32_sve(simsimd_f32_t const *a, simsimd_f32_t co
     simsimd_f32_t ab = svaddv_f32(svptrue_b32(), ab_vec);
     simsimd_f32_t a2 = svaddv_f32(svptrue_b32(), a2_vec);
     simsimd_f32_t b2 = svaddv_f32(svptrue_b32(), b2_vec);
+    SIMSIMD_UNPOISON(&ab, sizeof(ab));
+    SIMSIMD_UNPOISON(&a2, sizeof(a2));
+    SIMSIMD_UNPOISON(&b2, sizeof(b2));
     *result = _simsimd_cos_normalize_f64_neon(ab, a2, b2);
 }
 
@@ -852,6 +856,7 @@ SIMSIMD_PUBLIC void simsimd_l2sq_f64_sve(simsimd_f64_t const *a, simsimd_f64_t c
         i += svcntd();
     } while (i < n);
     simsimd_f64_t d2 = svaddv_f64(svptrue_b32(), d2_vec);
+    SIMSIMD_UNPOISON(&d2, sizeof(d2));
     *result = d2;
 }
 
@@ -874,6 +879,9 @@ SIMSIMD_PUBLIC void simsimd_cos_f64_sve(simsimd_f64_t const *a, simsimd_f64_t co
     simsimd_f64_t ab = svaddv_f64(svptrue_b32(), ab_vec);
     simsimd_f64_t a2 = svaddv_f64(svptrue_b32(), a2_vec);
     simsimd_f64_t b2 = svaddv_f64(svptrue_b32(), b2_vec);
+    SIMSIMD_UNPOISON(&ab, sizeof(ab));
+    SIMSIMD_UNPOISON(&a2, sizeof(a2));
+    SIMSIMD_UNPOISON(&b2, sizeof(b2));
     *result = _simsimd_cos_normalize_f64_neon(ab, a2, b2);
 }
 
@@ -906,6 +914,7 @@ SIMSIMD_PUBLIC void simsimd_l2sq_f16_sve(simsimd_f16_t const *a_enum, simsimd_f1
         i += svcnth();
     } while (i < n);
     simsimd_f16_for_arm_simd_t d2_f16 = svaddv_f16(svptrue_b16(), d2_vec);
+    SIMSIMD_UNPOISON(&d2_f16, sizeof(d2_f16));
     *result = d2_f16;
 }
 
@@ -930,6 +939,9 @@ SIMSIMD_PUBLIC void simsimd_cos_f16_sve(simsimd_f16_t const *a_enum, simsimd_f16
     simsimd_f16_for_arm_simd_t ab = svaddv_f16(svptrue_b16(), ab_vec);
     simsimd_f16_for_arm_simd_t a2 = svaddv_f16(svptrue_b16(), a2_vec);
     simsimd_f16_for_arm_simd_t b2 = svaddv_f16(svptrue_b16(), b2_vec);
+    SIMSIMD_UNPOISON(&ab, sizeof(ab));
+    SIMSIMD_UNPOISON(&a2, sizeof(a2));
+    SIMSIMD_UNPOISON(&b2, sizeof(b2));
     *result = _simsimd_cos_normalize_f32_neon(ab, a2, b2);
 }
 
@@ -973,7 +985,11 @@ SIMSIMD_PUBLIC void simsimd_l2sq_bf16_sve(simsimd_bf16_t const *a_enum, simsimd_
         d2_high_vec = svmla_f32_x(pg_high_vec, d2_high_vec, a_minus_b_high_vec, a_minus_b_high_vec);
         i += svcnth();
     } while (i < n);
-    simsimd_f32_t d2 = svaddv_f32(svptrue_b32(), d2_low_vec) + svaddv_f32(svptrue_b32(), d2_high_vec);
+    simsimd_f32_t d2_low = svaddv_f32(svptrue_b32(), d2_low_vec);
+    simsimd_f32_t d2_high = svaddv_f32(svptrue_b32(), d2_high_vec);
+    SIMSIMD_UNPOISON(&d2_low, sizeof(d2_low));
+    SIMSIMD_UNPOISON(&d2_high, sizeof(d2_high));
+    simsimd_f32_t d2 = d2_low + d2_high;
     *result = d2;
 }
 
@@ -998,6 +1014,9 @@ SIMSIMD_PUBLIC void simsimd_cos_bf16_sve(simsimd_bf16_t const *a_enum, simsimd_b
     simsimd_f32_t ab = svaddv_f32(svptrue_b32(), ab_vec);
     simsimd_f32_t a2 = svaddv_f32(svptrue_b32(), a2_vec);
     simsimd_f32_t b2 = svaddv_f32(svptrue_b32(), b2_vec);
+    SIMSIMD_UNPOISON(&ab, sizeof(ab));
+    SIMSIMD_UNPOISON(&a2, sizeof(a2));
+    SIMSIMD_UNPOISON(&b2, sizeof(b2));
     *result = _simsimd_cos_normalize_f32_neon(ab, a2, b2);
 }
 

--- a/include/simsimd/types.h
+++ b/include/simsimd/types.h
@@ -21,6 +21,22 @@
 #define _SIMSIMD_DEFINED_LINUX 1
 #endif
 
+// MemorySanitizer does not instrument ARM SVE intrinsics — there is zero handling of
+// `aarch64_sve_*` intrinsics in LLVM's MemorySanitizer.cpp (as of LLVM 20), only a
+// file-level "FIXME: This sanitizer does not yet handle scalable vectors".
+// This causes false positives when SVE reductions like `svaddv` produce scalar results
+// that MSan considers uninitialized. We unpoison these scalars explicitly.
+// See also: https://github.com/llvm/llvm-project/pull/165028
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#include <sanitizer/msan_interface.h>
+#define SIMSIMD_UNPOISON(ptr, size) __msan_unpoison((ptr), (size))
+#endif
+#endif
+#ifndef SIMSIMD_UNPOISON
+#define SIMSIMD_UNPOISON(ptr, size) (void)(ptr), (void)(size)
+#endif
+
 // Annotation for the public API symbols:
 //
 // - `SIMSIMD_PUBLIC` is used for functions that are part of the public API.


### PR DESCRIPTION
LLVM's MSan does not instrument ARM SVE intrinsics — there is zero handling of `aarch64_sve_*` in `MemorySanitizer.cpp` (as of LLVM 20), only a file-level `FIXME: This sanitizer does not yet handle scalable vectors`. This causes false positives when `svaddv` produces scalar results that MSan considers uninitialized.

Add `SIMSIMD_UNPOISON` calls after every `svaddv` reduction in SVE function bodies across `spatial.h`, `dot.h`, `binary.h`, and `sparse.h`. Define the macro in `types.h` with `__msan_unpoison` when MSan is active.

See also: https://github.com/llvm/llvm-project/pull/165028
Upstream PR: https://github.com/ashvardanian/NumKong/pull/342